### PR TITLE
Fix documentation for onDropDownClosed callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ export class AppComponent implements OnInit {
   Example : (onDeSelect)="onItemDeSelect($event)"
 - `onFilterChange` - Return the key press.
   Example : (onFilterChange)="onFilterChange($event)"
-- `onDropdownClose`-
-  Example : (onDropdownClose)="onDropdownClose()"
+- `onDropDownClose`-
+  Example : (onDropDownClose)="onDropDownClose()"
 
 ## Run locally
 


### PR DESCRIPTION
In the readme the `onDropDownClosed` event is described as `onDropdownClose` (note the Down is capitalized for the actual method). 
Attempting to use `(onDropdownClosed)="..."` will not trigger anything when the dropdown is closed.