### PR TITLE
add a classed span around the item text

### DIFF
--- a/src/ng-multiselect-dropdown/src/multi-select.component.html
+++ b/src/ng-multiselect-dropdown/src/multi-select.component.html
@@ -3,7 +3,7 @@
     <span tabindex="-1" class="dropdown-btn" (click)="toggleDropdown($event)">
       <span *ngIf="selectedItems.length == 0">{{_placeholder}}</span>
       <span class="selected-item" *ngFor="let item of selectedItems;trackBy: trackByFn;let k = index" [hidden]="k > _settings.itemsShowLimit-1">
-        {{item.text}}
+        <span class="selected-item-text">{{item.text}}</span>
         <a style="padding-top:2px;padding-left:2px;color:white" (click)="onItemClick($event,item)">x</a>
       </span>
       <span style="float:right !important;padding-right:4px">


### PR DESCRIPTION
as it is, if an item's text is too long when selected and one wants to add an ellipsis to it, the ellipsis must be added in the "selected-item" css class, which isn't ideal since it will add the A element to the ellipsis, therefore preventing the deletion of the selection
by surrounding the item's text with a span with a proper css class, one can manipulate the selected item's text without acting upon the anchor