### PR TITLE
Making Default Config configurable via InjectionToken or .forRoot(configs)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,8 +1,8 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-
-import { TabsModule, ButtonsModule } from 'ngx-bootstrap';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { NgMultiSelectDropDownModule } from '../ng-multiselect-dropdown/src';
 // import { NgMultiSelectDropDownModule } from 'ng-multiselect-dropdown';
 

--- a/src/ng-multiselect-dropdown/src/list-filter.pipe.ts
+++ b/src/ng-multiselect-dropdown/src/list-filter.pipe.ts
@@ -15,6 +15,6 @@ export class ListFilterPipe implements PipeTransform {
     }
 
     applyFilter(item: ListItem, filter: ListItem): boolean {
-        return !(filter.text && item.text && item.text.toLowerCase().indexOf(filter.text.toLowerCase()) === -1);
+        return !(filter.text && item.text && item.text.toString().toLowerCase().indexOf(filter.text.toString().toLowerCase()) === -1);
     }
 }

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -1,6 +1,7 @@
-import { Component, HostListener, forwardRef, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, HostListener, forwardRef, Inject, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { ListItem, IDropdownSettings } from './multiselect.model';
+import { NgMultiSelectDefaultConfig } from './ng-multiselect-default-config';
 
 export const DROPDOWN_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -23,25 +24,6 @@ export class MultiSelectComponent implements ControlValueAccessor {
   public isDropdownOpen = true;
   _placeholder = 'Select';
   filter: ListItem = new ListItem(this.data);
-  defaultSettings: IDropdownSettings = {
-    singleSelection: false,
-    idField: 'id',
-    textField: 'text',
-    disabledField: 'isDisabled',
-    enableCheckAll: true,
-    selectAllText: 'Select All',
-    unSelectAllText: 'UnSelect All',
-    allowSearchFilter: false,
-    limitSelection: -1,
-    clearSearchFilter: true,
-    maxHeight: 197,
-    itemsShowLimit: 999999999999,
-    searchPlaceholderText: 'Search',
-    noDataAvailablePlaceholderText: 'No data available',
-    closeDropDownOnSelection: false,
-    showSelectedItemsAtTop: false,
-    defaultOpen: false
-  };
 
   @Input()
   public set placeholder(value: string) {
@@ -109,7 +91,7 @@ export class MultiSelectComponent implements ControlValueAccessor {
     this.onFilterChange.emit($event);
   }
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, @Inject(NgMultiSelectDefaultConfig) private defaultSettings: IDropdownSettings) {}
 
   onItemClick($event: any, item: ListItem) {
     if (this.disabled || item.isDisabled) {

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -42,9 +42,9 @@ export class MultiSelectComponent implements ControlValueAccessor {
   @Input()
   public set settings(value: IDropdownSettings) {
     if (value) {
-      this._settings = Object.assign(this.defaultSettings, value);
+      this._settings = Object.assign({}, this.defaultSettings, value);
     } else {
-      this._settings = Object.assign(this.defaultSettings);
+      this._settings = Object.assign({}, this.defaultSettings);
     }
   }
 

--- a/src/ng-multiselect-dropdown/src/ng-multiselect-default-config.ts
+++ b/src/ng-multiselect-dropdown/src/ng-multiselect-default-config.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { IDropdownSettings } from './multiselect.model';
+
+export const NgMultiSelectDefaultConfig = new InjectionToken<IDropdownSettings>("NgMultiSelectDefaultConfig")

--- a/src/ng-multiselect-dropdown/src/ng-multiselect-dropdown.module.ts
+++ b/src/ng-multiselect-dropdown/src/ng-multiselect-dropdown.module.ts
@@ -4,17 +4,42 @@ import { FormsModule } from '@angular/forms';
 import { MultiSelectComponent } from './multiselect.component';
 import { ClickOutsideDirective } from './click-outside.directive';
 import { ListFilterPipe } from './list-filter.pipe';
+import { IDropdownSettings } from './multiselect.model';
+import { NgMultiSelectDefaultConfig } from './ng-multiselect-default-config';
+
+const DEFAULT_CONFIGS = {
+  singleSelection: false,
+  idField: 'id',
+  textField: 'text',
+  disabledField: 'isDisabled',
+  enableCheckAll: true,
+  selectAllText: 'Select All',
+  unSelectAllText: 'UnSelect All',
+  allowSearchFilter: false,
+  limitSelection: -1,
+  clearSearchFilter: true,
+  maxHeight: 197,
+  itemsShowLimit: 999999999999,
+  searchPlaceholderText: 'Search',
+  noDataAvailablePlaceholderText: 'No data available',
+  closeDropDownOnSelection: false,
+  showSelectedItemsAtTop: false,
+  defaultOpen: false
+};
 
 @NgModule({
   imports: [CommonModule, FormsModule],
   declarations: [MultiSelectComponent, ClickOutsideDirective, ListFilterPipe],
   exports: [MultiSelectComponent]
 })
-
 export class NgMultiSelectDropDownModule {
-    static forRoot(): ModuleWithProviders {
+    static forRoot(config?: IDropdownSettings): ModuleWithProviders {
       return {
-        ngModule: NgMultiSelectDropDownModule
+        ngModule: NgMultiSelectDropDownModule,
+        providers: [{
+          provide: NgMultiSelectDefaultConfig,
+          useValue: Object.assign(DEFAULT_CONFIGS, config)
+        }]
       };
     }
 }

--- a/src/ng-multiselect-dropdown/src/public_api.ts
+++ b/src/ng-multiselect-dropdown/src/public_api.ts
@@ -1,3 +1,4 @@
 export { MultiSelectComponent } from './multiselect.component';
 export { NgMultiSelectDropDownModule } from './ng-multiselect-dropdown.module';
 export { IDropdownSettings } from './multiselect.model';
+export { NgMultiSelectDefaultConfig } from './ng-multiselect-default-config';

--- a/src/ng-multiselect-dropdown/test/helper.ts
+++ b/src/ng-multiselect-dropdown/test/helper.ts
@@ -4,14 +4,14 @@ import { TestBed, ComponentFixture, tick } from '@angular/core/testing';
 import { NgMultiSelectDropDownModule } from './../src/ng-multiselect-dropdown.module';
 
 export function newEvent(eventName: string, bubbles = false, cancelable = false) {
-    let evt = document.createEvent('CustomEvent'); // MUST be 'CustomEvent'
+    const evt = document.createEvent('CustomEvent'); // MUST be 'CustomEvent'
     evt.initCustomEvent(eventName, bubbles, cancelable, null);
     return evt;
 }
 
 export function createTestingModule<T>(cmp: Type<T>, template: string): ComponentFixture<T> {
     TestBed.configureTestingModule({
-        imports: [FormsModule, NgMultiSelectDropDownModule],
+        imports: [FormsModule, NgMultiSelectDropDownModule.forRoot()],
         declarations: [cmp]
     })
         .overrideComponent(cmp, {


### PR DESCRIPTION
Making default configs configurable.

Via Provider:

```
  providers: [{
    provide: NgMultiSelectDefaultConfig,
    useValue: {
      textField: 'texto',
      disabledField: 'isDisabled',
      enableCheckAll: true,
      selectAllText: 'Selecionad Todos',
      unSelectAllText: 'Descelecionar Todos',
      allowSearchFilter: true,
      clearSearchFilter: true,
      searchPlaceholderText: 'Pesquisar',
      noDataAvailablePlaceholderText: 'Nenhum registro',
    }
  }],
```

Via .forRoot(config)

```
NgMultiSelectDropDownModule.forRoot({
   textField: 'texto',
   disabledField: 'isDisabled',
   enableCheckAll: true,
   selectAllText: 'Selecionad Todos',
   unSelectAllText: 'Descelecionar Todos',
   allowSearchFilter: true,
   clearSearchFilter: true,
   searchPlaceholderText: 'Pesquisar',
   noDataAvailablePlaceholderText: 'Nenhum registro',
}),
```
