### PR TITLE
Update Readme.md for Angular 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ export class AppComponent implements OnInit {
 ```html
 <ng-multiselect-dropdown
   [placeholder]="'custom placeholder'"
+  [settings]="dropdownSettings"
   [data]="dropdownList"
   [(ngModel)]="selectedItems"
-  [settings]="dropdownSettings"
   (onSelect)="onItemSelect($event)"
   (onSelectAll)="onSelectAll($event)"
 >


### PR DESCRIPTION
In Angular 9 it causes 'idField' as undefined if we declare 'data' param before 'settings' param. So, it should be updated in the doc for newer users. 
I faced the same error and find the solution in on the issue (216 - https://github.com/NileshPatel17/ng-multiselect-dropdown/issues/216#issue-579874095). 
Thanks