### PR TITLE
Add onDropDownOpen() output

### DIFF
--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -89,6 +89,10 @@ export class MultiSelectComponent implements ControlValueAccessor {
 
   @Output("onFilterChange")
   onFilterChange: EventEmitter<ListItem> = new EventEmitter<any>();
+  
+  @Output("onDropDownOpen")
+  onDropDownOpen: EventEmitter<ListItem> = new EventEmitter<any>();
+  
   @Output("onDropDownClose")
   onDropDownClose: EventEmitter<ListItem> = new EventEmitter<any>();
 
@@ -291,6 +295,7 @@ export class MultiSelectComponent implements ControlValueAccessor {
   toggleDropdown(evt) {
     evt.preventDefault();
     if (this.disabled && this._settings.singleSelection) {
+      this.onDropDownOpen.emit();
       return;
     }
     this._settings.defaultOpen = !this._settings.defaultOpen;


### PR DESCRIPTION
Adding this will allow users to synchronize custom behavior based on whether the dropdown is opened or close.  For example, have a complementary palette of UI controls open and close along side the multiselect.