### PR TITLE
Npm install fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~12.7.2",
     "angular-cli-ghpages": "^0.6.0-rc.2",
-    "angular-library-builder": "^1.5.12",
     "angular2-markdown": "^2.2.3",
     "codelyzer": "~5.1.0",
     "copyfiles": "^2.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,8 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { TabsModule, ButtonsModule } from 'ngx-bootstrap';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { NgMultiSelectDropDownModule } from '../ng-multiselect-dropdown/src';
 // import { NgMultiSelectDropDownModule } from 'ng-multiselect-dropdown';
 


### PR DESCRIPTION
These were fixes I required to be able to install and build this project.
The angular-library-builder package is old and deprecated and was trying to install a really old version of node-sass.
The ngx-bootstrap import method being used is also deprecated and it was throwing errors trying to import it. 

Fixes #202 