### PR TITLE
Stop onDropDownClose from firing when dropdown already closed

### DIFF
--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -300,14 +300,14 @@ export class MultiSelectComponent implements ControlValueAccessor {
   }
 
   closeDropdown() {
-    // clear search text
-    if (this._settings.clearSearchFilter) {
-      this.filter.text = "";
-    }
-    // Only emit the close dropdown event if the dropdown was open.
+    // If the dropdown isn't open, don't do anything.
     if (this._settings.defaultOpen) {
-      this.onDropDownClose.emit();
       this._settings.defaultOpen = false;
+      // clear search text.
+      if (this._settings.clearSearchFilter) {
+        this.filter.text = "";
+      }
+      this.onDropDownClose.emit();
     }
   }
 

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -302,7 +302,7 @@ export class MultiSelectComponent implements ControlValueAccessor {
   closeDropdown() {
     // clear search text
     if (this._settings.clearSearchFilter) {
-      this.filter.text = '';
+      this.filter.text = "";
     }
     // Only emit the close dropdown event if the dropdown was open.
     if (this._settings.defaultOpen) {

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -300,12 +300,15 @@ export class MultiSelectComponent implements ControlValueAccessor {
   }
 
   closeDropdown() {
-    this._settings.defaultOpen = false;
     // clear search text
     if (this._settings.clearSearchFilter) {
-      this.filter.text = "";
+      this.filter.text = '';
     }
-    this.onDropDownClose.emit();
+    // Only emit the close dropdown event if the dropdown was open.
+    if (this._settings.defaultOpen) {
+      this.onDropDownClose.emit();
+      this._settings.defaultOpen = false;
+    }
   }
 
   toggleSelectAll() {


### PR DESCRIPTION
Currently the click outside directive triggers the closeDropdown() function any time a click happens outside the multiselect, and it triggers the event emission even if the dropdown wasn't open to begin with.

Fixes #127 