### PR TITLE
Allow CSS targeting on text

### DIFF
--- a/src/ng-multiselect-dropdown/src/multi-select.component.html
+++ b/src/ng-multiselect-dropdown/src/multi-select.component.html
@@ -3,7 +3,7 @@
     <span tabindex="-1" class="dropdown-btn" (click)="toggleDropdown($event)">
       <span *ngIf="selectedItems.length == 0">{{_placeholder}}</span>
       <span class="selected-item" *ngFor="let item of selectedItems;trackBy: trackByFn;let k = index" [hidden]="k > _settings.itemsShowLimit-1">
-        {{item.text}}
+        <span>{{item.text}}</span>
         <a style="padding-top:2px;padding-left:2px;color:white" (click)="onItemClick($event,item)">x</a>
       </span>
       <span style="float:right !important;padding-right:4px">


### PR DESCRIPTION
I have a use case to make the selected value in single selection to use ellipses when text overflowed. However, it's impossible to do that without ended up hiding the X button because the text is targeted with the <a>. Wrapping {{item.text}} with <span> allows it to be targeted by css
Despite my best effort to style it, the X button can't show in 1 line when text overflow happened
![image](https://user-images.githubusercontent.com/30759367/94849754-834d2100-03eb-11eb-8556-2d96c9f36917.png)
