### PR TITLE
Search filter "No filtered data found" message added + Dropdown close/reopen issue fixed

### DIFF
--- a/src/ng-multiselect-dropdown/src/multi-select.component.html
+++ b/src/ng-multiselect-dropdown/src/multi-select.component.html
@@ -27,6 +27,9 @@
         <input type="checkbox" [attr.aria-label]="item.text" [checked]="isSelected(item)" [disabled]="disabled || (isLimitSelectionReached() && !isSelected(item)) || item.isDisabled" />
         <div>{{item.text}}</div>
       </li>
+      <li class='no-filtered-data' *ngIf="_data.length != 0 && (_data | multiSelectFilter:filter).length == 0 && !_settings.allowRemoteDataSearch">
+        <h5>{{_settings.noFilteredDataAvailablePlaceholderText}}</h5>
+      </li>
       <li class='no-data' *ngIf="_data.length == 0 && !_settings.allowRemoteDataSearch">
         <h5>{{_settings.noDataAvailablePlaceholderText}}</h5>
       </li>

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -41,6 +41,7 @@ export class MultiSelectComponent implements ControlValueAccessor {
     itemsShowLimit: 999999999999,
     searchPlaceholderText: "Search",
     noDataAvailablePlaceholderText: "No data available",
+    noFilteredDataAvailablePlaceholderText: "No filtered data available",
     closeDropDownOnSelection: false,
     showSelectedItemsAtTop: false,
     defaultOpen: false,

--- a/src/ng-multiselect-dropdown/src/multiselect.component.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.component.ts
@@ -187,7 +187,7 @@ export class MultiSelectComponent implements ControlValueAccessor {
   // Set touched on blur
   @HostListener("blur")
   public onTouched() {
-    this.closeDropdown();
+    // this.closeDropdown();
     this.onTouchedCallback();
   }
 

--- a/src/ng-multiselect-dropdown/src/multiselect.model.ts
+++ b/src/ng-multiselect-dropdown/src/multiselect.model.ts
@@ -13,6 +13,7 @@ export interface IDropdownSettings {
   limitSelection?: number;
   searchPlaceholderText?: string;
   noDataAvailablePlaceholderText?: string;
+  noFilteredDataAvailablePlaceholderText?: string;
   closeDropDownOnSelection?: boolean;
   showSelectedItemsAtTop?: boolean;
   defaultOpen?: boolean;


### PR DESCRIPTION
[1] 
Shows new placeholder text when no data is found during a search.
Shows :
![image](https://user-images.githubusercontent.com/25748500/121819704-28730580-ccac-11eb-90d5-ba60f509810f.png)
Instead of 
![image](https://user-images.githubusercontent.com/25748500/121819725-47719780-ccac-11eb-882b-55a5817d72b4.png)

[2]
closeDropdown() is not required in "blur" hostlistener as it is already covered in [clickOutside] ClickOutsideDirective.
Turns out this closeDropdown was causing #198 #295 #302 and #309 

Reference:
[1] [Pipe filter empty check](https://stackoverflow.com/questions/37067138/angular-2-check-if-pipe-returns-an-empty-subset-of-original-list)
[2] [YHGxG's comment in issue thread](https://github.com/NileshPatel17/ng-multiselect-dropdown/issues/295#issuecomment-841507832)