### PR TITLE
Improve displayed items for large text options

### DIFF
--- a/src/ng-multiselect-dropdown/src/multi-select.component.scss
+++ b/src/ng-multiselect-dropdown/src/multi-select.component.scss
@@ -21,15 +21,16 @@ $disable-background-color: #eceeef;
     .selected-item-container {
       display: flex;
       float: left;
+      max-width: 93%;
       .selected-item{
         border: 1px solid $base-color;
         margin-right: 4px;
+        margin-bottom: 4px;
         background: $base-color;
         padding: 0px 5px;
         color: #fff;
         border-radius: 2px;
-        float: left;        
-        max-width: 100px;      
+        float: left;
         span {
           overflow: hidden;
           text-overflow: ellipsis;


### PR DESCRIPTION
Better display for large and long text options;

Below two screenshots after and before to show the difference:

**Before :** 
<img width="277" alt="before" src="https://user-images.githubusercontent.com/23366612/166144895-d8cf0089-0dd3-4e55-9f65-d39134497120.png">

**after:** 
<img width="277" alt="after" src="https://user-images.githubusercontent.com/23366612/166144903-fc4607c4-99e7-4bbe-9bfc-0e2667292bfa.png">
